### PR TITLE
Add Terraform configuration for Cloud Run service and IAM invokers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release Authentication
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    name: Deploy to Google Cloud Run
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Authenticate with Google Cloud
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS_CD }}
+          project_id: intricate-pad-455413-f7
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.5.7
+
+      - name: Terraform Init
+        run: terraform -chdir=terraform init
+
+      - name: Terraform Apply
+        run: terraform -chdir=terraform apply -auto-approve

--- a/terraform/cloudRun.tf
+++ b/terraform/cloudRun.tf
@@ -1,0 +1,33 @@
+module "cloud_run_frontend-service" {
+  source                = "./modules/cloud_run"
+  project_id            = "intricate-pad-455413-f7"
+  region                = "europe-west1"
+  service_name          = "frontend-service"
+  repository_id         = "locaccm-repo-docker"
+  service_account_email = module.service_account_frontend-service.email
+  vpc_connector         = module.vpc_connector.id
+  public                = false
+
+  env_variables = {
+    NODE_ENV = "production"
+  }
+}
+
+module "cloud_run_frontend-service_invokers" {
+  depends_on = [module.cloud_run_frontend-service]
+  source        = "./modules/cloud_run_invoker"
+  region        = "europe-west1"
+  service_name  = "frontend-service"
+  invokers = {
+    authentification    = "auth-service@intricate-pad-455413-f7.iam.gserviceaccount.com"
+    adminmanagement     = "adminmanagement-service@intricate-pad-455413-f7.iam.gserviceaccount.com"
+    wealthmanagement    = "wealthmanagement-service@intricate-pad-455413-f7.iam.gserviceaccount.com"
+    notification        = "notification-service@intricate-pad-455413-f7.iam.gserviceaccount.com"
+    dashboardmanagement = "dashboardmanagement-service@intricate-pad-455413-f7.iam.gserviceaccount.com"
+    chats               = "chats-service@intricate-pad-455413-f7.iam.gserviceaccount.com"
+    documentmanagement  = "documentmanagement-service@intricate-pad-455413-f7.iam.gserviceaccount.com"
+    calendarmanagement  = "calendarmanagement-service@intricate-pad-455413-f7.iam.gserviceaccount.com"
+    housingallocation   = "housingallocation-service@intricate-pad-455413-f7.iam.gserviceaccount.com"
+    profilemanagement   = "profilemanagement-service@intricate-pad-455413-f7.iam.gserviceaccount.com"
+  }
+}

--- a/terraform/modules/cloud_run/main.tf
+++ b/terraform/modules/cloud_run/main.tf
@@ -1,0 +1,37 @@
+resource "google_cloud_run_service" "service" {
+  name     = var.service_name
+  location = var.region
+
+  template {
+    metadata {
+      annotations = {
+        "run.googleapis.com/vpc-access-connector" = var.vpc_connector
+        }
+    }
+
+    spec {
+      containers {
+        image = "europe-west1-docker.pkg.dev/${var.project_id}/${var.repository_id}/${var.service_name}:latest"
+
+        ports {
+          container_port = 3000
+        }
+
+        dynamic "env" {
+          for_each = var.env_variables
+          content {
+            name  = env.key
+            value = env.value
+          }
+        }
+      }
+
+      service_account_name = var.service_account_email
+    }
+  }
+
+  traffic {
+    percent         = 100
+    latest_revision = true
+  }
+}

--- a/terraform/modules/cloud_run/outputs.tf
+++ b/terraform/modules/cloud_run/outputs.tf
@@ -1,0 +1,4 @@
+output "service_url" {
+  description = "URL of the deployed Cloud Run service"
+  value       = google_cloud_run_service.service.status[0].url
+}

--- a/terraform/modules/cloud_run/variables.tf
+++ b/terraform/modules/cloud_run/variables.tf
@@ -1,0 +1,41 @@
+variable "project_id" {
+  type        = string
+  description = "GCP project ID"
+}
+
+variable "region" {
+  type        = string
+  description = "GCP region"
+}
+
+variable "service_name" {
+  type        = string
+  description = "Name of the Cloud Run service"
+}
+
+variable "repository_id" {
+  type        = string
+  description = "Artifact Registry Docker repository ID"
+}
+
+variable "service_account_email" {
+  type        = string
+  description = "Email of the service account to run the Cloud Run service"
+}
+
+variable "vpc_connector" {
+  type        = string
+  description = "Fully qualified name of the VPC connector"
+}
+
+variable "public" {
+  type        = bool
+  default     = false
+  description = "Whether to make the Cloud Run service public"
+}
+
+variable "env_variables" {
+  type        = map(string)
+  default     = {}
+  description = "Environment variables to inject into the container"
+}

--- a/terraform/modules/cloud_run_invoker/main.tf
+++ b/terraform/modules/cloud_run_invoker/main.tf
@@ -1,0 +1,8 @@
+resource "google_cloud_run_service_iam_member" "invokers" {
+  for_each = var.invokers
+
+  location = var.region
+  service  = var.service_name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${each.value}"
+}

--- a/terraform/modules/cloud_run_invoker/outputs.tf
+++ b/terraform/modules/cloud_run_invoker/outputs.tf
@@ -1,0 +1,3 @@
+output "applied_invokers" {
+  value = [for sa in var.invokers : sa]
+}

--- a/terraform/modules/cloud_run_invoker/variables.tf
+++ b/terraform/modules/cloud_run_invoker/variables.tf
@@ -1,0 +1,14 @@
+variable "region" {
+  description = "Region of the Cloud Run service"
+  type        = string
+}
+
+variable "service_name" {
+  description = "Name of the Cloud Run service to grant access to"
+  type        = string
+}
+
+variable "invokers" {
+  description = "Map of invokers (caller_id => service_account_email)"
+  type        = map(string)
+}

--- a/terraform/modules/service_account/main.tf
+++ b/terraform/modules/service_account/main.tf
@@ -1,0 +1,12 @@
+resource "google_service_account" "this" {
+  account_id   = var.account_id
+  display_name = var.display_name
+}
+
+resource "google_project_iam_member" "roles" {
+  for_each = toset(var.roles)
+
+  project = var.project_id
+  role    = each.value
+  member  = "serviceAccount:${google_service_account.this.email}"
+}

--- a/terraform/modules/service_account/outputs.tf
+++ b/terraform/modules/service_account/outputs.tf
@@ -1,0 +1,3 @@
+output "email" {
+  value = google_service_account.this.email
+}

--- a/terraform/modules/service_account/variables.tf
+++ b/terraform/modules/service_account/variables.tf
@@ -1,0 +1,19 @@
+variable "account_id" {
+  description = "ID of the service account (unique)"
+  type        = string
+}
+
+variable "display_name" {
+  description = "Display name of the service account"
+  type        = string
+}
+
+variable "project_id" {
+  description = "Project ID where the service account is created"
+  type        = string
+}
+
+variable "roles" {
+  description = "List of IAM roles to assign to this service account"
+  type        = list(string)
+}

--- a/terraform/modules/vpc_connector/main.tf
+++ b/terraform/modules/vpc_connector/main.tf
@@ -1,0 +1,9 @@
+resource "google_vpc_access_connector" "this" {
+  name           = var.name
+  region         = var.region
+  network        = var.network
+  ip_cidr_range  = var.ip_cidr_range
+
+  min_throughput = 200
+  max_throughput = 300
+}

--- a/terraform/modules/vpc_connector/outputs.tf
+++ b/terraform/modules/vpc_connector/outputs.tf
@@ -1,0 +1,11 @@
+output "id" {
+  value = google_vpc_access_connector.this.id
+}
+
+output "name" {
+  value = google_vpc_access_connector.this.name
+}
+
+output "self_link" {
+  value = google_vpc_access_connector.this.self_link
+}

--- a/terraform/modules/vpc_connector/variables.tf
+++ b/terraform/modules/vpc_connector/variables.tf
@@ -1,0 +1,20 @@
+
+variable "name" {
+  description = "Name of the VPC connector"
+  type        = string
+}
+
+variable "region" {
+  description = "Region of the VPC connector"
+  type        = string
+}
+
+variable "network" {
+  description = "The VPC network name"
+  type        = string
+}
+
+variable "ip_cidr_range" {
+  description = "CIDR range for VPC connector IPs"
+  type        = string
+}

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,0 +1,5 @@
+provider "google" {
+  project     = "intricate-pad-455413-f7"
+  region      = "europe-west1"
+  zone        = "europe-west1-d"
+}

--- a/terraform/serviceAccount.tf
+++ b/terraform/serviceAccount.tf
@@ -1,0 +1,10 @@
+module "service_account_frontend-service" {
+  source       = "./modules/service_account"
+  account_id   = "frontend-service"
+  display_name = "Frontend Service Account"
+  project_id   = "intricate-pad-455413-f7"
+  roles        = [
+    "roles/cloudsql.client",
+    "roles/storage.objectViewer"
+  ]
+}

--- a/terraform/vpcConnector.tf
+++ b/terraform/vpcConnector.tf
@@ -1,0 +1,7 @@
+module "vpc_connector" {
+  source         = "./modules/vpc_connector"
+  name           = "locaccm-vpc-connector"
+  region         = "europe-west1"
+  network        = "locaccm-vpc"
+  ip_cidr_range  = "10.8.0.0/28"
+}


### PR DESCRIPTION
This pull request introduces a comprehensive setup for deploying a frontend service to Google Cloud Run using Terraform and GitHub Actions. The changes include defining infrastructure modules for Cloud Run, service accounts, VPC connectors, and IAM roles, as well as creating a GitHub Actions workflow for automated deployment.

### GitHub Actions Workflow:
* Added a new workflow in `.github/workflows/release.yml` to automate deployment to Google Cloud Run. It includes steps for repository checkout, Google Cloud authentication, Terraform initialization, and applying infrastructure changes.

### Cloud Run Deployment:
* Defined a `cloud_run` Terraform module in `terraform/modules/cloud_run/main.tf` for deploying Cloud Run services, including support for environment variables, VPC connectors, and service accounts.
* Added an output in `terraform/modules/cloud_run/outputs.tf` to expose the deployed service's URL.
* Declared input variables in `terraform/modules/cloud_run/variables.tf` for configuration flexibility (e.g., project ID, region, service name).

### Service Accounts and IAM Roles:
* Created a `service_account` module in `terraform/modules/service_account/main.tf` to manage service accounts and assign IAM roles.
* Configured a service account for the frontend service in `terraform/serviceAccount.tf` with roles for Cloud SQL and storage access.

### VPC Connector:
* Added a `vpc_connector` module in `terraform/modules/vpc_connector/main.tf` to configure a VPC connector for secure networking.
* Set up a VPC connector in `terraform/vpcConnector.tf` with a specific CIDR range and network name.

### Infrastructure Provider Configuration:
* Configured the Google Cloud provider in `terraform/provider.tf` with the project, region, and zone settings.