### PR TITLE
Refactor IAM member assignment logic for Cloud Run invokers

### DIFF
--- a/terraform/modules/cloud_run_invoker/main.tf
+++ b/terraform/modules/cloud_run_invoker/main.tf
@@ -4,7 +4,5 @@ resource "google_cloud_run_service_iam_member" "invokers" {
   location = var.region
   service  = var.service_name
   role     = "roles/run.invoker"
-  member = startswith(each.value, "allUsers") || startswith(each.value, "allAuthenticatedUsers")
-    ? each.value
-    : "serviceAccount:${each.value}"
+  member   = contains(["allUsers", "allAuthenticatedUsers"], each.value) ? each.value : "serviceAccount:${each.value}"
 }


### PR DESCRIPTION
This pull request refactors the logic for assigning IAM members in the `google_cloud_run_service_iam_member` resource to improve readability and maintainability.

### Refactor of IAM member assignment logic:
* [`terraform/modules/cloud_run_invoker/main.tf`](diffhunk://#diff-fb8029f855e05ee1751de5a66c4ce9aa0cbb68397f88b9f2e34698f111b16bb7L7-R7): Simplified the conditional logic for determining the `member` value by replacing `startswith` checks with a `contains` function, making the code more concise and easier to understand.