### PR TITLE
Add account deletion functionality with confirmation in ProfileForm

### DIFF
--- a/src/components/profilManagement/ProfileForm.tsx
+++ b/src/components/profilManagement/ProfileForm.tsx
@@ -89,6 +89,34 @@ const ProfileForm = () => {
         }
     };
 
+    const handleDeleteAccount = async () => {
+        if (!userId || !token) return;
+
+        const confirmed = window.confirm("Es-tu sûr de vouloir supprimer ton compte ? Cette action est irréversible.");
+        if (!confirmed) return;
+
+        try {
+            const res = await fetch(
+                `${import.meta.env.VITE_PROFILE_URL}profiles/${userId}`,
+                {
+                    method: "DELETE",
+                    headers: {
+                        Authorization: `Bearer ${token}`,
+                    },
+                },
+            );
+
+            if (!res.ok) throw new Error("Échec de la suppression");
+
+            alert("Compte supprimé avec succès.");
+            sessionStorage.clear();
+            window.location.href = "/";
+        } catch (err) {
+            console.error("Erreur suppression compte :", err);
+            alert("Erreur lors de la suppression du compte.");
+        }
+    };
+
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
         if (!token) {
@@ -187,6 +215,16 @@ const ProfileForm = () => {
       <button type="submit" className="button primary">
         Enregistrer
       </button>
+
+        <button
+            type="button"
+            className="button danger"
+            onClick={handleDeleteAccount}
+            style={{ marginTop: "1rem" }}
+        >
+            Supprimer mon compte
+        </button>
+
     </form>
   );
 };

--- a/src/pages/profileManagement/styles.module.css
+++ b/src/pages/profileManagement/styles.module.css
@@ -1,0 +1,12 @@
+.button.danger {
+    background-color: #e74c3c;
+    color: white;
+    border: none;
+    padding: 0.6rem 1.2rem;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.button.danger:hover {
+    background-color: #c0392b;
+}

--- a/src/tests/components/ProfileManagement/ProfileForm.test.tsx
+++ b/src/tests/components/ProfileManagement/ProfileForm.test.tsx
@@ -178,4 +178,58 @@ describe("ProfileForm", () => {
     expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
+
+  test("supprime le compte après confirmation", async () => {
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockProfile,
+    } as Response);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+    } as Response);
+
+    vi.spyOn(window, "confirm").mockReturnValueOnce(true);
+    vi.spyOn(window, "alert").mockImplementation(() => {});
+    vi.stubGlobal("location", { href: "", assign: vi.fn() });
+
+    render(<ProfileForm />);
+
+    const deleteButton = await screen.findByText("Supprimer mon compte");
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+          expect.stringContaining("profiles/1"),
+          expect.objectContaining({
+            method: "DELETE",
+            headers: {
+              Authorization: "Bearer mock-token",
+            },
+          })
+      );
+    });
+  });
+
+
+  test("ne supprime pas le compte si l'utilisateur annule", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockProfile,
+    } as Response);
+
+    vi.spyOn(window, "confirm").mockReturnValueOnce(false);
+
+    render(<ProfileForm />);
+    const deleteButton = await screen.findByText("Supprimer mon compte");
+
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+
 });


### PR DESCRIPTION
This pull request enhances the `ProfileForm` component by adding functionality for deleting user accounts, styling for the new button, and tests to ensure the feature works correctly. The most important changes include implementing the account deletion logic, adding a "Delete Account" button with corresponding styles, and updating the test suite to cover the new functionality.

### New Account Deletion Feature:
* **Account deletion logic**: Added the `handleDeleteAccount` function to handle user account deletion with confirmation, error handling, and session cleanup.
* **"Delete Account" button**: Added a button to the form for triggering the account deletion process, styled as "danger" to indicate its critical nature.

### Styling Updates:
* **Button styling**: Added `.button.danger` CSS class for the "Delete Account" button, including hover effects for better user experience.

### Test Suite Enhancements:
* **Account deletion tests**: Added tests to verify the account deletion flow, including scenarios for successful deletion and user cancellation.