### PR TITLE
style: add danger button styles for error indication

### DIFF
--- a/src/assets/styles/styles.css
+++ b/src/assets/styles/styles.css
@@ -697,5 +697,17 @@ button {
   color: white;
 }
 
+.button.danger {
+  background-color: #e74c3c;
+  color: white;
+  border: none;
+  padding: 0.6rem 1.2rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.button.danger:hover {
+  background-color: #c0392b;
+}
 
 


### PR DESCRIPTION
This pull request introduces a new `.button.danger` style in the `styles.css` file to provide a consistent design for "danger" buttons.

Styling changes:

* [`src/assets/styles/styles.css`](diffhunk://#diff-e633e9fa974dfeb55c839031d5405d98be26a0658e8031744dd096bdd688853aR700-R711): Added `.button.danger` class with properties for background color, text color, border, padding, border radius, and cursor behavior, along with hover state styling for a darker background color.